### PR TITLE
Start of rerun

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2021"
 [dependencies]
 env_logger = "0.11.3"
 log = "0.4.21"
+multi_log = "0.1.2"
+pretty_env_logger = "0.5.0"
 rerun = "0.16.0"
+simplelog = "0.12.2"

--- a/src/basher_rerun/mod.rs
+++ b/src/basher_rerun/mod.rs
@@ -1,0 +1,125 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use rerun::RecordingStreamBuilder;
+
+pub type BashRerunHandle = Arc<Mutex<BasherRerun>>;
+#[derive(Debug, Clone, PartialEq)]
+pub enum RerunMode {
+    Save,
+    Live,
+    Spawn,
+}
+#[derive(Debug, Clone)]
+pub struct BasherRerun {
+    pub name: String,
+    pub group: String,
+    pub run_id: String,
+    pub rerun: Option<rerun::RecordingStream>,
+    rerun_override: Option<RerunMode>,
+}
+
+impl BasherRerun {
+    pub fn new(name: String, group: String, run_id: String) -> Self {
+        BasherRerun {
+            rerun: None,
+            name,
+            group,
+            run_id,
+            rerun_override: None,
+        }
+    }
+
+    pub fn create_rerun(&mut self) {
+        let app_id = format!("{}/{}", self.group, self.name);
+        let rerun_mode = self.get_rerun_mode();
+        let path = self.get_rerun_save_path(&self.group);
+        let rec = match rerun_mode {
+            RerunMode::Save => RecordingStreamBuilder::new(app_id)
+                .recording_id(self.run_id.clone())
+                .save(path.join(format!("{}.rrd", self.name)))
+                .unwrap(),
+            RerunMode::Spawn => RecordingStreamBuilder::new(app_id)
+                .recording_id(self.run_id.clone())
+                .spawn()
+                .unwrap(),
+            _ => RecordingStreamBuilder::new(app_id).connect().unwrap(),
+        };
+
+        if rerun_mode != RerunMode::Save {
+            // Or log via a logging handler:
+            rerun::Logger::new(rec.clone()) // recording streams are ref-counted
+                .with_path_prefix("logs/handler")
+                // You can also use the standard `RUST_LOG` environment variable!
+                .with_filter(rerun::default_log_filter())
+                .init()
+                .expect("Failed to initialize logger");
+            log::info!("This INFO log got added through the standard logging interface");
+        }
+
+        self.rerun = Some(rec);
+    }
+
+    pub fn handle(&self) -> BashRerunHandle {
+        Arc::new(Mutex::new(self.clone()))
+    }
+
+    pub fn rerun(&self) -> Option<rerun::RecordingStream> {
+        self.rerun.clone()
+    }
+
+    pub fn set_rerun_live(&mut self) {
+        self.rerun_override = Some(RerunMode::Live);
+    }
+
+    pub fn set_rerun_save(&mut self) {
+        self.rerun_override = Some(RerunMode::Save);
+    }
+
+    /// Get the current rerun mode
+    ///
+    /// If self.rerun_override is Some, return that value
+    ///
+    /// else will read from the environment variable RERUN_MODE (LIVE, SAVE)
+    pub fn get_rerun_mode(&self) -> RerunMode {
+        match self.rerun_override {
+            Some(RerunMode::Live) => RerunMode::Live,
+            Some(RerunMode::Save) => RerunMode::Save,
+            _ => Self::get_rerun_env(),
+        }
+    }
+
+    pub fn get_rerun_env() -> RerunMode {
+        let rerun_mode: String = std::env::var("RERUN_MODE").unwrap_or("SAVE".to_string());
+        match rerun_mode.as_str().to_uppercase().as_str() {
+            "LIVE" => RerunMode::Live,
+            "SAVE" => RerunMode::Save,
+            "SPAWN" => RerunMode::Spawn,
+            _ => RerunMode::Save,
+        }
+    }
+    /// Get the path to save the rerun data
+    ///
+    /// This will be the root workspace path, and will create a folder
+    /// .basher/logs
+    ///
+    pub fn get_rerun_save_path(&self, group: &str) -> PathBuf {
+        let path = PathBuf::new()
+            // Root workspace path
+            .join(Path::new(env!("CARGO_MANIFEST_DIR")))
+            .join(Path::new(".basher/logs"))
+            .join(group);
+        //.join(now.to_string());
+        if !path.exists() {
+            std::fs::create_dir_all(&path).unwrap();
+        }
+        // Empty folder
+        for entry in std::fs::read_dir(&path).unwrap() {
+            let entry = entry.unwrap();
+            std::fs::remove_file(entry.path()).unwrap();
+        }
+        path
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+mod basher_rerun;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,32 @@
-use log::info;
 
+use basher_rerun::BasherRerun;
+use ::log::LevelFilter;
+use ::rerun::{Scalar, SeriesPoint};
+use ::log::info;
+use rerun::*;
+use simplelog::{ColorChoice, CombinedLogger, Config, TermLogger, TerminalMode};
+mod basher_rerun;
 fn main() {
-    env_logger::init();
-    info!("[Basher Main] Starting Basher...")
-}
+    //TOOD: Expose this to its own configurable logging setting, lua? 
+    let mode = BasherRerun::get_rerun_env();
+    if mode == basher_rerun::RerunMode::Save {
+        pretty_env_logger::init();
+        info!("[Basher Main] Running in save mode, using CLI based rerun");
+    } 
 
+
+    let mut rerun = basher_rerun::BasherRerun::new("basher".to_string(), "manual".to_string(), "999".to_string());
+    rerun.create_rerun(); 
+  
+    info!("[Basher Main] Starting Basher...");
+
+    for i in 0..10 {
+        info!("[Basher Main] Iteration {}", i);
+        rerun.rerun().unwrap().set_time_seconds("time", i);
+        rerun.rerun().unwrap().log("test_data", &Scalar::new(i as f64)).expect("Failed to log data");
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
### TL;DR

Implemented BasherRerun module for logging and visualization with Rerun integration.

### What changed?

- Added new dependencies: multi_log, pretty_env_logger, and simplelog
- Created a new `basher_rerun` module with `BasherRerun` struct and related functionality
- Implemented different Rerun modes: Save, Live, and Spawn
- Updated main.rs to use the new BasherRerun module
- Added configurable logging based on Rerun mode

### How to test?

1. Run the application with different RERUN_MODE environment variables:
   - `RERUN_MODE=SAVE`: Saves logs to .basher/logs directory
   - `RERUN_MODE=LIVE`: Connects to Rerun viewer in real-time
   - `RERUN_MODE=SPAWN`: Spawns a new Rerun viewer instance
2. Verify that logs are generated and visualized correctly in each mode
3. Check the iteration loop in main.rs, which logs test data for 10 seconds

### Why make this change?

This change introduces a flexible logging and visualization system using Rerun, allowing for better debugging and data analysis capabilities. It provides different modes of operation to suit various development and production scenarios, enhancing the overall observability of the application.

---

